### PR TITLE
MONGOID-5603 railsmdb dbconsole

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 
 group :development, :test do
   gem 'rake'
+  gem 'rspec'
 end

--- a/lib/railsmdb/commands/dbconsole/dbconsole_command.rb
+++ b/lib/railsmdb/commands/dbconsole/dbconsole_command.rb
@@ -52,8 +52,8 @@ module Mongoid
 
         config = Mongoid.clients[:default]
         unless config
-          warn "There is no default configuration to fall back to.\n" \
-               'Please define a client in config/mongoid.yml.'
+          abort "There is no default configuration to fall back to.\n" \
+                'Please define a client in config/mongoid.yml.'
         end
 
         warn 'Using default configuration instead.'

--- a/lib/railsmdb/commands/dbconsole/dbconsole_command.rb
+++ b/lib/railsmdb/commands/dbconsole/dbconsole_command.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails/command/base'
+require 'rails/command/environment_argument'
+
+module Mongoid
+  module Command
+    # The implementation of the `dbconsole` command for Railsmdb.
+    class DbconsoleCommand < Rails::Command::Base
+      include Rails::Command::EnvironmentArgument
+
+      desc 'dbconsole', 'Start a console for MongoDB using the info in config/mongoid.yml'
+      def perform
+        require_application_and_environment!
+        exec_mongosh_with(Rails.env || 'default')
+      end
+
+      private
+
+      # Invokes mongosh using the config/mongoid.yml configuration for the
+      # current Rails environment. If no such configuration exists, it tries
+      # to fall back to the `default` configuration.
+      #
+      # @param [ String ] environment the named configuration to use.
+      def exec_mongosh_with(environment)
+        puts "Launching mongosh with #{environment} configuration."
+        config = find_configuration_for(environment)
+
+        command = ENV['MONGOSH_CMD'] || 'mongosh'
+
+        uri = config[:uri] || "mongodb://#{config[:hosts].first}/#{config[:database]}"
+
+        exec(command, uri)
+      rescue Errno::ENOENT
+        abort "mongosh is not installed, or is not in your PATH. Please see\n" \
+              "https://www.mongodb.com/docs/mongodb-shell for instructions on\n" \
+              'downloading and installing mongosh.'
+      end
+
+      # Looks for a Mongoid client configuration with the given name. If no
+      # such configuration exists, tries to load the `default` configuration.
+      # If that can't be found, it will abort executation.
+      #
+      # @param [ String ] environment the name of the configuration to load.
+      #
+      # @return [ Hash ] the named configuration
+      def find_configuration_for(environment)
+        config = Mongoid.clients[environment]
+        return config if config
+
+        warn "There is no #{environment} configuration defined in config/mongoid.yml."
+
+        config = Mongoid.clients[:default]
+        unless config
+          warn "There is no default configuration to fall back to.\n" \
+               'Please define a client in config/mongoid.yml.'
+        end
+
+        warn 'Using default configuration instead.'
+        config
+      end
+    end
+  end
+end

--- a/spec/fixtures/config/mongoid_yml_with_db_and_hosts
+++ b/spec/fixtures/config/mongoid_yml_with_db_and_hosts
@@ -1,0 +1,8 @@
+development:
+  clients:
+    default:
+      database: test_app_development
+      hosts:
+        - host1.com:1234
+        - host2.com:2345
+        - host3.com:3456

--- a/spec/fixtures/config/mongoid_yml_with_uri
+++ b/spec/fixtures/config/mongoid_yml_with_uri
@@ -1,0 +1,4 @@
+development:
+  clients:
+    default:
+      uri: mongodb://user:password@mongodb.domain.com:27017/test_app_development

--- a/spec/railsmdb/dbconsole_spec.rb
+++ b/spec/railsmdb/dbconsole_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+app_name = 'test_app'
+missing_program = '/path/to/missing/program'
+
+describe 'railsmdb dbconsole' do
+  # Helper method for replacing the generated app's config/mongoid.yml file
+  # with the given fixture file.
+  def self.write_mongoid_yml_with(features)
+    before(:context) do
+      write_file(
+        'config/mongoid.yml',
+        fixture_from(:config, "mongoid_yml_with_#{features}")
+      )
+    end
+  end
+
+  when_running_railsmdb 'new', app_name do
+    it_succeeds
+
+    within_folder app_name do
+      context 'when mongosh is installed' do
+        write_mongoid_yml_with(:db_and_hosts)
+
+        # we're replacing `mongosh` with `echo`, so we can confirm that the
+        # command is run with the expected parameters.
+        when_running_bin_railsmdb 'dbconsole', env: { MONGOSH_CMD: 'echo' } do
+          it_succeeds
+          it_prints 'mongodb://host1.com:1234/test_app_development'
+          it_warns 'no development configuration'
+        end
+      end
+
+      context 'when mongosh is not installed' do
+        when_running_bin_railsmdb 'dbconsole',
+                                  env: { MONGOSH_CMD: missing_program } do
+          it_fails
+          it_warns 'mongosh is not installed'
+        end
+      end
+
+      context 'when mongoid.yml specifies a uri' do
+        write_mongoid_yml_with(:uri)
+
+        when_running_bin_railsmdb 'dbconsole', env: { MONGOSH_CMD: 'echo' } do
+          it_succeeds
+          it_prints 'mongodb://user:password@mongodb.domain.com:27017/test_app_development'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This implements `railsmdb dbconsole`, by calling exec with `mongosh` and the URI (or host/port/database) given in the app's `config/mongoid.yml` file.