### PR TITLE
MONGOID-5604 railsmdb db:seed

### DIFF
--- a/lib/railsmdb/ext/rails/generators/rails/app/app_generator.rb
+++ b/lib/railsmdb/ext/rails/generators/rails/app/app_generator.rb
@@ -137,10 +137,7 @@ module Rails
       def mongoid_gem_entries
         {
           nil => [
-            mongoid_gem_entry
-          ],
-
-          development: [
+            mongoid_gem_entry,
             railsmdb_gem_entry
           ]
         }
@@ -168,12 +165,12 @@ module Rails
       def railsmdb_gem_entry
         if railsmdb_project_directory.present?
           GemfileEntry.path \
-            'railsmdb',
+            'mongoid-railsmdb',
             railsmdb_project_directory,
             'The development version of railsmdb'
         else
           GemfileEntry.version \
-            'railsmdb',
+            'mongoid-railsmdb',
             Railsmdb::Version::STRING,
             'The Rails CLI tool for MongoDB'
         end

--- a/lib/railsmdb/ext/rails/generators/rails/app/app_generator.rb
+++ b/lib/railsmdb/ext/rails/generators/rails/app/app_generator.rb
@@ -56,6 +56,12 @@ module Rails
       # The following methods override the existing methods on AppGenerator,
       # to replace the default behavior with Mongoid-specific behavior.
 
+      # Overridden to ignore the "skip_active_record" guard. We always want the
+      # db folder, even when active record is being skipped.
+      def create_db_files
+        build(:db)
+      end
+
       # Overridden to save the current directory; this way, we can see
       # if it is being run from the railsmdb project directory, in
       # development, and set up the railsmdb gem dependency appropriately.

--- a/railsmdb.gemspec
+++ b/railsmdb.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'railsmdb/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'railsmdb'
+  s.name        = 'mongoid-railsmdb'
   s.version     = Railsmdb::Version::STRING
   s.authors     = [ 'The MongoDB Ruby Team' ]
   s.email       = 'dbx-ruby@mongodb.com'
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
   # FIXME: populate the metadata fields
   s.metadata = {
     'rubygems_mfa_required' => 'true',
-    # 'bug_tracker_uri' => 'https://jira.mongodb.org/projects/MONGOID',
-    # 'changelog_uri' => 'https://github.com/mongodb/railsmdb/releases',
+    'bug_tracker_uri' => 'https://jira.mongodb.org/projects/MONGOID',
+    'changelog_uri' => 'https://github.com/mongodb/mongoid-railsmdb/releases',
     # 'documentation_uri' => '',
     # 'homepage_uri' => '',
-    # 'source_code_uri' => 'https://github.com/mongodb/railsmdb'
+    'source_code_uri' => 'https://github.com/mongodb/mongoid-railsmdb'
   }
 
   if File.exist?('gem-private_key.pem')

--- a/spec/railsmdb/new_spec.rb
+++ b/spec/railsmdb/new_spec.rb
@@ -16,7 +16,7 @@ describe 'railsmdb new' do
       it_emits_file 'config/mongoid.yml', containing: "database: #{app_name}_development"
       it_emits_file 'config/initializers/mongoid.rb', containing: 'Mongoid.configure do'
       it_does_not_emit_file 'config/database.yml'
-      it_does_not_emit_folder 'db'
+      it_emits_file 'db/seeds.rb'
       it_does_not_emit_file 'app/models/application_record.rb'
 
       when_running_bin_railsmdb 'new', other_app_name do


### PR DESCRIPTION
The good news is that this was already implemented via Mongoid. All that was needed in railsmdb was to make sure that the `db` folder was not suppressed, so that the `db/seeds.rb` file would be present.