### PR TITLE
MONGOID-5706 Depend on mongoid-odm instead of mongoid

### DIFF
--- a/railsmdb.gemspec
+++ b/railsmdb.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 2.7'
   s.add_dependency 'minitar', '~> 0.9'
   s.add_dependency 'rubyzip', '~> 2.3'
-  s.add_dependency 'mongoid', '>= 8.0'
+  s.add_dependency 'mongoid-odm', '>= 8.0'
 
   s.required_ruby_version = '>= 3.0'
 end


### PR DESCRIPTION
In order to allow mongoid to depend on railsmdb, we need to change `mongoid` to be a meta-gem, which in turn depends on `mongoid-odm` (see https://github.com/mongodb/mongoid/pull/5766). This updates the `railsmdb` gem so that it depends on the `mongoid-odm` gem as well, thus breaking the circular dependency.
